### PR TITLE
DatasetMerge fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ setuptools
 packaging
 importlib_metadata
 polars
+pyarrow


### PR DESCRIPTION
Resolved critical error when performing `DatasetMerge`. The previous merging caused cell indices to get mixed.

Working example [here](https://github.com/Gautam8387/scarf-pr-exp/blob/main/issues/03-merge-data-fix/merge.ipynb)